### PR TITLE
Upgrade to GPflow 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains an implementation of several online/streaming sparse GP
 
 We also provide an implementation of the collapsed batch Power-EP sparse approximation of Bui, Yan and Turner (2017).
 
-The code was tested using GPflow 0.4.0 and tensorflow 1.2 on a Linux machine and a Mac. Note that latest GPflow breaks backward-compatibility.
+The code was tested using GPflow 2.5 and 2.6 and TensorFlow 2.5.
 
 ## Usage
 
@@ -17,6 +17,7 @@ We provide several test scripts ([regression](code/run_reg_toy.py) and [classifi
 ## Contributors
 
 Thang D. Bui, Cuong V. Nguyen and Richard E. Turner
+[ST John](github.com/st--/)
 
 ## References: 
 

--- a/code/osgpr.py
+++ b/code/osgpr.py
@@ -168,7 +168,7 @@ class OSGPR_VFE(GPModel, InternalDataTrainingLossMixin):
         mean = tf.matmul(LDinv_Lbinv_Kbs, LDinv_Lbinv_c, transpose_a=True)
 
         if full_cov:
-            Kss = self.kernel(Xnew) # + jitter * tf.eye(tf.shape(Xnew)[0], dtype=gpflow.default_float())  # TODO
+            Kss = self.kernel(Xnew) + jitter * tf.eye(tf.shape(Xnew)[0], dtype=gpflow.default_float())
             var1 = Kss
             var2 = - tf.matmul(Lbinv_Kbs, Lbinv_Kbs, transpose_a=True)
             var3 = tf.matmul(LDinv_Lbinv_Kbs, LDinv_Lbinv_Kbs, transpose_a=True)
@@ -362,7 +362,7 @@ class OSGPR_PEP(GPModel, InternalDataTrainingLossMixin):
         mean = tf.matmul(LDinv_Lbinv_Kbs, LDinv_c, transpose_a=True)
 
         if full_cov:
-            Kss = self.kernel(Xnew) # + jitter * tf.eye(tf.shape(Xnew)[0], dtype=gpflow.default_float())  # TODO
+            Kss = self.kernel(Xnew) + jitter * tf.eye(tf.shape(Xnew)[0], dtype=gpflow.default_float())
             var1 = Kss
             var2 = - tf.matmul(Lbinv_Kbs, Lbinv_Kbs, transpose_a=True)
             var3 = tf.matmul(LDinv_Lbinv_Kbs, LDinv_Lbinv_Kbs, transpose_a=True)

--- a/code/osvgpc.py
+++ b/code/osvgpc.py
@@ -61,7 +61,6 @@ class OSVGPC(GPModel, InternalDataTrainingLossMixin):
         return kullback_leiblers.prior_kl(self.inducing_variable, self.kernel, self.q_mu, self.q_sqrt, whiten=self.whiten)
 
     def correction_term(self):
-        # TODO
         Mb = self.inducing_variable.num_inducing
         Ma = self.M_old
         # jitter = gpflow.default_jitter()
@@ -70,9 +69,9 @@ class OSVGPC(GPModel, InternalDataTrainingLossMixin):
         ma = self.mu_old
         # a is old inducing points, b is new
         mu, Sigma = self.predict_f(self.Z_old, full_cov=True)
-        Sigma = Sigma[0, :, :]   # TODO is this right!???
+        Sigma = tf.squeeze(Sigma, axis=0)
         Smm = Sigma + tf.matmul(mu, mu, transpose_b=True)
-        Kaa = gpflow.utilities.add_noise_cov(self.Kaa_old, jitter)  # TODO check
+        Kaa = gpflow.utilities.add_noise_cov(self.Kaa_old, jitter)
         LSa = tf.linalg.cholesky(Saa)
         LKa = tf.linalg.cholesky(Kaa)
         obj = tf.reduce_sum(tf.math.log(tf.linalg.diag_part(LKa)))

--- a/code/osvgpc.py
+++ b/code/osvgpc.py
@@ -1,4 +1,3 @@
-
 import tensorflow as tf
 import numpy as np
 import gpflow
@@ -6,10 +5,7 @@ from gpflow import Parameter, default_float
 from gpflow import conditionals, kullback_leiblers
 from gpflow.inducing_variables import InducingPoints
 from gpflow.models import GPModel, InternalDataTrainingLossMixin
-from gpflow.mean_functions import Zero
 from gpflow.utilities import positive, triangular
-
-float_type = default_float()
 
 
 class OSVGPC(GPModel, InternalDataTrainingLossMixin):
@@ -24,8 +20,7 @@ class OSVGPC(GPModel, InternalDataTrainingLossMixin):
     def __init__(self, data, kernel, likelihood, mu_old, Su_old, Kaa_old, Z_old, Z, mean_function=None,
                  q_diag=False, whiten=True):
 
-        X, Y = gpflow.models.util.data_input_to_tensor(data)
-        self.X, self.Y = self.data = X, Y
+        self.data = gpflow.models.util.data_input_to_tensor(data)
         # self.num_data = X.shape[0]
         self.num_data = None
 
@@ -98,20 +93,20 @@ class OSVGPC(GPModel, InternalDataTrainingLossMixin):
         """
         This gives a variational bound on the model likelihood.
         """
+        X, Y = self.data
 
         # Get prior KL.
         kl = self.prior_kl()
 
         # Get conditionals
-        fmean, fvar = self.predict_f(self.X, full_cov=False)
+        fmean, fvar = self.predict_f(X, full_cov=False)
 
         # Get variational expectations.
-        var_exp = self.likelihood.variational_expectations(fmean, fvar, self.Y)
+        var_exp = self.likelihood.variational_expectations(fmean, fvar, Y)
 
         # re-scale for minibatch size
         if self.num_data is not None:
             raise NotImplementedError("need to update code to ExternalDataTrainingLossMixin")
-            X = self.X
             num_data = tf.cast(self.num_data, kl.dtype)
             minibatch_size = tf.cast(tf.shape(X)[0], kl.dtype)
             scale = num_data / minibatch_size

--- a/code/osvgpc.py
+++ b/code/osvgpc.py
@@ -6,6 +6,7 @@ from gpflow import conditionals, kullback_leiblers
 from gpflow.inducing_variables import InducingPoints
 from gpflow.models import GPModel, InternalDataTrainingLossMixin
 from gpflow.utilities import positive, triangular
+from packaging import version  # required to handle GPflow breaking changes
 
 
 class OSVGPC(GPModel, InternalDataTrainingLossMixin):
@@ -102,7 +103,11 @@ class OSVGPC(GPModel, InternalDataTrainingLossMixin):
         fmean, fvar = self.predict_f(X, full_cov=False)
 
         # Get variational expectations.
-        var_exp = self.likelihood.variational_expectations(fmean, fvar, Y)
+        if version.parse(gpflow.__version__) < version.Version("2.6.0"):
+            var_exp = self.likelihood.variational_expectations(fmean, fvar, Y)
+        else:
+            # breaking change https://github.com/GPflow/GPflow/pull/1919
+            var_exp = self.likelihood.variational_expectations(X, fmean, fvar, Y)
 
         # re-scale for minibatch size
         if self.num_data is not None:

--- a/code/run_cla_toy.py
+++ b/code/run_cla_toy.py
@@ -3,9 +3,7 @@
 
 import numpy as np
 import matplotlib as mpl
-import scipy.stats
 # mpl.use('pgf')
-import pdb
 
 
 def figsize(scale):
@@ -65,13 +63,9 @@ for i in range(len(tableau20)):
     r, g, b = tableau20[i]
     tableau20[i] = (r / 255., g / 255., b / 255.)
 
-import scipy as scp
 import gpflow
 import osvgpc
-import pdb
 import matplotlib.pyplot as plt
-import tensorflow as tf
-import matplotlib.ticker as ticker
 
 
 def init_Z(cur_Z, new_X, use_old_Z=True, first_batch=True):

--- a/code/run_cla_toy.py
+++ b/code/run_cla_toy.py
@@ -4,7 +4,7 @@
 import numpy as np
 import matplotlib as mpl
 import scipy.stats
-mpl.use('pgf')
+# mpl.use('pgf')
 import pdb
 
 

--- a/code/run_cla_toy.py
+++ b/code/run_cla_toy.py
@@ -171,9 +171,6 @@ def run_vfe(no_batches, M, use_old_Z, iid):
             model = osvgpc.OSVGPC((Xi, yi), gpflow.kernels.RBF(lengthscales=np.ones(2)),
                                   gpflow.likelihoods.Bernoulli(),
                                   mu, Su, Kaa, Zopt, Zinit)
-            # TODO: what does this do: ???
-            # model.kern.variance = model.kern.variance.value
-            # model.kern.lengthscales = model.kern.lengthscales.value
             gpflow.optimizers.Scipy().minimize(
                 model.training_loss, model.trainable_variables,
                 options=dict(disp=1, maxiter=maxiter))

--- a/code/run_reg_toy.py
+++ b/code/run_reg_toy.py
@@ -3,8 +3,7 @@
 
 import numpy as np
 import matplotlib as mpl
-import scipy.stats
-mpl.use('pgf')
+# mpl.use('pgf')
 
 def figsize(scale, ratio=None):
     fig_width_pt = 397.4849                         # Get this from LaTeX using \the\textwidth
@@ -50,15 +49,10 @@ mpl.rcParams['xtick.color'] = grey
 mpl.rcParams['ytick.color'] = grey
 mpl.rcParams['axes.labelcolor'] = "black"
 
-import scipy as scp
-# import sys
-# sys.path.append('/scratch/tdb40/sandbox/GPflow/gpflow')
-import gpflow as GPflow
+import gpflow
 import osgpr
-import sgpr
-import pdb
+# import sgpr
 import matplotlib.pyplot as plt
-import tensorflow as tf
 import matplotlib.ticker as ticker
 
 def init_Z(cur_Z, new_X, use_old_Z=True, first_batch=True):
@@ -76,10 +70,10 @@ def init_Z(cur_Z, new_X, use_old_Z=True, first_batch=True):
 
 def plot_model(model, ax, cur_x, cur_y, pred_x, seen_x=None, seen_y=None):
     mx, vx = model.predict_f(pred_x)
-    Zopt = model.Z.value
-    mu, Su = model.predict_f_full_cov(Zopt)
+    Zopt = model.inducing_variable.Z.numpy()
+    mu, Su = model.predict_f(Zopt, full_cov=True)
     if len(Su.shape) == 3:
-        Su = Su[:, :, 0]
+        Su = Su[0, :, :]
         vx = vx[:, 0]
     ax.plot(cur_x, cur_y, 'kx', mew=1, alpha=0.8)
     if seen_x is not None:
@@ -105,7 +99,7 @@ def get_data(shuffle):
     X = X.reshape(X.shape[0], 1)
     y = y.reshape((y.shape[0], 1))
     N = y.shape[0]
-    gap = N/3
+    gap = N//3
     X[:gap, :] = X[:gap, :] - 1
     X[2*gap:3*gap, :] = X[2*gap:3*gap, :] + 1
     if shuffle:
@@ -113,6 +107,12 @@ def get_data(shuffle):
         X = X[idxs, :]
         y = y[idxs, :]
     return X, y
+
+
+def optimize(model, **options):
+    gpflow.optimizers.Scipy().minimize(
+        model.training_loss, model.trainable_variables,
+        options=options)
 
 
 def plot_PEP_optimized(M, alpha, use_old_Z, shuffle):
@@ -130,11 +130,9 @@ def plot_PEP_optimized(M, alpha, use_old_Z, shuffle):
     # Z1 = np.random.rand(M, 1)*L
     Z1 = X1[np.random.permutation(X1.shape[0])[0:M], :]
 
-    model1 = sgpr.SGPR_PEP(X1, y1, GPflow.kernels.RBF(1), Z=Z1, alpha=alpha)
-    model1.likelihood.variance = 0.001
-    model1.kern.variance = 1.0
-    model1.kern.lengthscales = 0.8
-    model1.optimize(disp=1)
+    model1 = sgpr.SGPR_PEP(X1, y1, gpflow.kernels.RBF(variance=1.0, lengthscales=0.8), Z=Z1, alpha=alpha)
+    model1.likelihood.variance.assign(0.001)
+    optimize(model1, disp=1)
 
     # plot prediction
     xx = np.linspace(-2, 12, 100)[:,None]
@@ -146,21 +144,13 @@ def plot_PEP_optimized(M, alpha, use_old_Z, shuffle):
     seen_x = X[:gap, :]
     seen_y = y[:gap, :]
 
-    x_free = tf.placeholder('float64')
-    model1.kern.make_tf_array(x_free)
-    X_tf = tf.placeholder('float64')
-    with model1.kern.tf_mode():
-        Kaa1 = tf.Session().run(
-            model1.kern.K(X_tf), 
-            feed_dict={x_free: model1.kern.get_free_state(), X_tf: model1.Z.value})
+    Kaa1 = model1.kernel(model1.inducing_variable.Z)
 
     Zinit = init_Z(Zopt, X2, use_old_Z)
-    model2 = osgpr.OSGPR_PEP(X2, y2, GPflow.kernels.RBF(1), mu1, Su1, Kaa1, 
+    model2 = osgpr.OSGPR_PEP((X2, y2), gpflow.kernels.RBF(variance=model1.kernel.variance, lengthscales=model1.kernel.lengthscales), mu1, Su1, Kaa1, 
         Zopt, Zinit, alpha)
-    model2.likelihood.variance = model1.likelihood.variance.value
-    model2.kern.variance = model1.kern.variance.value
-    model2.kern.lengthscales = model1.kern.lengthscales.value
-    model2.optimize(disp=1)
+    model2.likelihood.variance.assign(model1.likelihood.variance)
+    optimize(model2, disp=1)
 
     # plot prediction
     mu2, Su2, Zopt = plot_model(model2, axs[1], X2, y2, xx, seen_x, seen_y)
@@ -171,31 +161,22 @@ def plot_PEP_optimized(M, alpha, use_old_Z, shuffle):
     seen_x = np.vstack((seen_x, X2))
     seen_y = np.vstack((seen_y, y2))
 
-    x_free = tf.placeholder('float64')
-    model2.kern.make_tf_array(x_free)
-    X_tf = tf.placeholder('float64')
-    with model2.kern.tf_mode():
-        Kaa2 = tf.Session().run(model2.kern.K(X_tf), 
-            feed_dict={x_free: model2.kern.get_free_state(), X_tf: model2.Z.value})
+    Kaa2 = model2.kernel(model2.inducing_variable.Z)
 
     Zinit = init_Z(Zopt, X3, use_old_Z)
-    model3 = osgpr.OSGPR_PEP(X3, y3, GPflow.kernels.RBF(1), mu2, Su2, Kaa2, 
+    model3 = osgpr.OSGPR_PEP((X3, y3), gpflow.kernels.RBF(variance=model2.kernel.variance, lengthscales=model2.kernel.lengthscales), mu2, Su2, Kaa2, 
         Zopt, Zinit, alpha)
-    model3.likelihood.variance = model2.likelihood.variance.value
-    model3.kern.variance = model2.kern.variance.value
-    model3.kern.lengthscales = model2.kern.lengthscales.value
+    model3.likelihood.variance.assign(model2.likelihood.variance)
+    optimize(model3, disp=1)
 
-    model3.optimize(disp=1)
     mu3, Su3, Zopt = plot_model(model3, axs[2], X3, y3, xx, seen_x, seen_y)
     axs[2].set_xlabel('x')
 
 
     Z4 = X[np.random.permutation(X.shape[0])[0:M], :]
-    model4 = sgpr.SGPR_PEP(X, y, GPflow.kernels.RBF(1), Z=Z4, alpha=alpha)
-    model4.likelihood.variance = 0.001
-    model4.kern.variance = 1.0
-    model4.kern.lengthscales = 0.8
-    model4.optimize(disp=1)
+    model4 = sgpr.SGPR_PEP(X, y, gpflow.kernels.RBF(variance=1.0, lengthscales=0.8), Z=Z4, alpha=alpha)
+    model4.likelihood.variance.assign(0.001)
+    optimize(model4, disp=1)
 
     # plot prediction
     xx = np.linspace(-2, 12, 100)[:,None]
@@ -212,7 +193,7 @@ def plot_VFE_optimized(M, use_old_Z, shuffle):
     X, y = get_data(shuffle)
 
     N = X.shape[0]
-    gap = N/3
+    gap = N//3
 
     # get the first portion and call sparse GP regression
     X1 = X[:gap, :]
@@ -222,11 +203,8 @@ def plot_VFE_optimized(M, use_old_Z, shuffle):
     # Z1 = np.random.rand(M, 1)*L
     Z1 = X1[np.random.permutation(X1.shape[0])[0:M], :]
 
-    model1 = GPflow.sgpr.SGPR(X1, y1, GPflow.kernels.RBF(1), Z=Z1)
-    model1.likelihood.variance = 0.001
-    model1.kern.variance = 1.0
-    model1.kern.lengthscales = 0.8
-    model1.optimize(disp=1)
+    model1 = gpflow.models.SGPR((X1, y1), gpflow.kernels.RBF(variance=1.0, lengthscales=0.8), inducing_variable=Z1, noise_variance=0.001)
+    optimize(model1, disp=1)
 
     # plot prediction
     xx = np.linspace(-2, 12, 100)[:,None]
@@ -238,21 +216,13 @@ def plot_VFE_optimized(M, use_old_Z, shuffle):
     seen_x = X[:gap, :]
     seen_y = y[:gap, :]
 
-    x_free = tf.placeholder('float64')
-    model1.kern.make_tf_array(x_free)
-    X_tf = tf.placeholder('float64')
-    with model1.kern.tf_mode():
-        Kaa1 = tf.Session().run(
-            model1.kern.K(X_tf), 
-            feed_dict={x_free: model1.kern.get_free_state(), X_tf: model1.Z.value})
+    Kaa1 = model1.kernel(model1.inducing_variable.Z)
 
     Zinit = init_Z(Zopt, X2, use_old_Z)
-    model2 = osgpr.OSGPR_VFE(X2, y2, GPflow.kernels.RBF(1), mu1, Su1, Kaa1, 
+    model2 = osgpr.OSGPR_VFE((X2, y2), gpflow.kernels.RBF(variance=model1.kernel.variance, lengthscales=model1.kernel.lengthscales), mu1, Su1, Kaa1, 
         Zopt, Zinit)
-    model2.likelihood.variance = model1.likelihood.variance.value
-    model2.kern.variance = model1.kern.variance.value
-    model2.kern.lengthscales = model1.kern.lengthscales.value
-    model2.optimize(disp=1)
+    model2.likelihood.variance.assign(model1.likelihood.variance)
+    optimize(model2, disp=1)
 
     # plot prediction
     mu2, Su2, Zopt = plot_model(model2, axs[1], X2, y2, xx, seen_x, seen_y)
@@ -263,29 +233,19 @@ def plot_VFE_optimized(M, use_old_Z, shuffle):
     seen_x = np.vstack((seen_x, X2))
     seen_y = np.vstack((seen_y, y2))
 
-    x_free = tf.placeholder('float64')
-    model2.kern.make_tf_array(x_free)
-    X_tf = tf.placeholder('float64')
-    with model2.kern.tf_mode():
-        Kaa2 = tf.Session().run(model2.kern.K(X_tf), 
-            feed_dict={x_free: model2.kern.get_free_state(), X_tf: model2.Z.value})
+    Kaa2 = model2.kernel(model2.inducing_variable.Z)
 
     Zinit = init_Z(Zopt, X3, use_old_Z)
-    model3 = osgpr.OSGPR_VFE(X3, y3, GPflow.kernels.RBF(1), mu2, Su2, Kaa2, 
+    model3 = osgpr.OSGPR_VFE((X3, y3), gpflow.kernels.RBF(variance=model2.kernel.variance, lengthscales=model2.kernel.lengthscales), mu2, Su2, Kaa2, 
         Zopt, Zinit)
-    model3.likelihood.variance = model2.likelihood.variance.value
-    model3.kern.variance = model2.kern.variance.value
-    model3.kern.lengthscales = model2.kern.lengthscales.value
-    model3.optimize(disp=1)
+    model3.likelihood.variance.assign(model2.likelihood.variance)
+    optimize(model3, disp=1)
     mu3, Su3, Zopt = plot_model(model3, axs[2], X3, y3, xx, seen_x, seen_y)
     
 
     Z4 = X[np.random.permutation(X.shape[0])[0:M], :]
-    model4 = GPflow.sgpr.SGPR(X, y, GPflow.kernels.RBF(1), Z=Z4)
-    model4.likelihood.variance = 0.001
-    model4.kern.variance = 1.0
-    model4.kern.lengthscales = 0.8
-    model4.optimize(disp=1)
+    model4 = gpflow.models.SGPR((X, y), gpflow.kernels.RBF(variance=1.0, lengthscales=0.8), inducing_variable=Z4, noise_variance=0.001)
+    optimize(model4, disp=1)
 
     # plot prediction
     xx = np.linspace(-2, 12, 100)[:,None]
@@ -300,8 +260,8 @@ if __name__ == '__main__':
     seed = 10
     shuffle = False
 
-    np.random.seed(seed)
-    plot_PEP_optimized(10, alpha, use_old_Z, shuffle)
+    # np.random.seed(seed)
+    # plot_PEP_optimized(10, alpha, use_old_Z, shuffle)
     np.random.seed(seed)
     plot_VFE_optimized(10, use_old_Z, shuffle)
 

--- a/code/run_reg_toy.py
+++ b/code/run_reg_toy.py
@@ -51,7 +51,7 @@ mpl.rcParams['axes.labelcolor'] = "black"
 
 import gpflow
 import osgpr
-# import sgpr
+import sgpr
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 
@@ -121,7 +121,7 @@ def plot_PEP_optimized(M, alpha, use_old_Z, shuffle):
     X, y = get_data(shuffle)
 
     N = X.shape[0]
-    gap = N/3
+    gap = N//3
     # get the first portion and call sparse GP regression
     X1 = X[:gap, :]
     y1 = y[:gap, :]
@@ -130,7 +130,7 @@ def plot_PEP_optimized(M, alpha, use_old_Z, shuffle):
     # Z1 = np.random.rand(M, 1)*L
     Z1 = X1[np.random.permutation(X1.shape[0])[0:M], :]
 
-    model1 = sgpr.SGPR_PEP(X1, y1, gpflow.kernels.RBF(variance=1.0, lengthscales=0.8), Z=Z1, alpha=alpha)
+    model1 = sgpr.SGPR_PEP((X1, y1), gpflow.kernels.RBF(variance=1.0, lengthscales=0.8), Z=Z1, alpha=alpha)
     model1.likelihood.variance.assign(0.001)
     optimize(model1, disp=1)
 
@@ -174,7 +174,7 @@ def plot_PEP_optimized(M, alpha, use_old_Z, shuffle):
 
 
     Z4 = X[np.random.permutation(X.shape[0])[0:M], :]
-    model4 = sgpr.SGPR_PEP(X, y, gpflow.kernels.RBF(variance=1.0, lengthscales=0.8), Z=Z4, alpha=alpha)
+    model4 = sgpr.SGPR_PEP((X, y), gpflow.kernels.RBF(variance=1.0, lengthscales=0.8), Z=Z4, alpha=alpha)
     model4.likelihood.variance.assign(0.001)
     optimize(model4, disp=1)
 
@@ -260,8 +260,8 @@ if __name__ == '__main__':
     seed = 10
     shuffle = False
 
-    # np.random.seed(seed)
-    # plot_PEP_optimized(10, alpha, use_old_Z, shuffle)
+    np.random.seed(seed)
+    plot_PEP_optimized(10, alpha, use_old_Z, shuffle)
     np.random.seed(seed)
     plot_VFE_optimized(10, use_old_Z, shuffle)
 

--- a/code/sgpr.py
+++ b/code/sgpr.py
@@ -116,7 +116,7 @@ class SGPR_PEP(GPModel, InternalDataTrainingLossMixin):
         mean = tf.matmul(LDinv_Lbinv_Kbs, LDinv_c, transpose_a=True)
 
         if full_cov:
-            Kss = self.kernel(Xnew) # + jitter * tf.eye(tf.shape(Xnew)[0], dtype=gpflow.default_float())  # TODO
+            Kss = self.kernel(Xnew) + jitter * tf.eye(tf.shape(Xnew)[0], dtype=gpflow.default_float())
             var1 = Kss
             var2 = - tf.matmul(Lbinv_Kbs, Lbinv_Kbs, transpose_a=True)
             var3 = tf.matmul(LDinv_Lbinv_Kbs, LDinv_Lbinv_Kbs, transpose_a=True)


### PR DESCRIPTION
This PR upgrades the code to run under current versions of GPflow & TensorFlow (tested with gpflow 2.5 and tensorflow 2.5).
Note that I could not test out the PEP version as it depends on an `sgpr` package that is not part of this code.